### PR TITLE
solved NLog issue

### DIFF
--- a/Promact.Oauth.Server/src/Promact.Oauth.Server/NLog.config
+++ b/Promact.Oauth.Server/src/Promact.Oauth.Server/NLog.config
@@ -1,11 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
-     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://www.nlog-project.org/schemas/NLog.xsd NLog.xsd">
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      autoReload="true"
+      internalLogLevel="Warn"
+      internalLogFile="c:\temp\internal-nlog.txt">
+
+  <!-- define various log targets -->
   <targets>
-    <target xsi:type="File" name="myfile" fileName="errorlog${shortdate}.log" layout="${longdate} ${logger} ${message}"/>
+    <target xsi:type="File" name="ownFile-web" fileName="nlog-${shortdate}.${level}.log"
+             layout="${longdate}|${event-properties:item=EventId.Id}|${logger}|${uppercase:${level}}|  ${message} ${exception}" />
+
+    <target xsi:type="Null" name="blackhole" />
   </targets>
+
   <rules>
-    <logger name="*" minlevel="Info" writeTo="myfile" final="true" />
+    <!--Skip Microsoft logs and so log only own logs-->
+    <logger name="Microsoft.*" minlevel="Trace" writeTo="blackhole" final="true" />
+    <logger name="*" minlevel="Debug" writeTo="ownFile-web" />
   </rules>
 </nlog>


### PR DESCRIPTION
1) right now only our application related logs are logged.
2) and solve this issue : Change the way log files are created. Now, It should create separate files for each verbosity. I.e., for information message there will be a different file, for error there will be a separate file and so on.