### PR TITLE
Register users not display in proper order

### DIFF
--- a/Promact.Oauth.Server/src/Promact.Oauth.Server/Repository/UserRepository/UserRepository.cs
+++ b/Promact.Oauth.Server/src/Promact.Oauth.Server/Repository/UserRepository/UserRepository.cs
@@ -210,7 +210,7 @@ namespace Promact.Oauth.Server.Repository
         /// <returns>List of all users</returns>
         public IEnumerable<UserAc> GetAllUsers()
         {
-            var users = _userManager.Users;
+            var users = _userManager.Users.OrderByDescending(x=>x.CreatedDateTime);
             //var users = await _applicationUserDataRepository.GetAll().ToListAsync();
             var userList = new List<UserAc>();
             foreach (var user in users)


### PR DESCRIPTION
Fixes #97 

Changes Proposed in this pull request :
UserRepository.cs : Update GetAllUsers method , display all user in the descending order of the creation