### PR TITLE
Issue of ExecuteDbDataReaderAsync occured by ListOfTeamLeaderByUserIdAsync 

### DIFF
--- a/Promact.Oauth.Server/src/Promact.Oauth.Server/Repository/UserRepository/UserRepository.cs
+++ b/Promact.Oauth.Server/src/Promact.Oauth.Server/Repository/UserRepository/UserRepository.cs
@@ -261,7 +261,8 @@ namespace Promact.Oauth.Server.Repository
             var user = await _userManager.Users.FirstOrDefaultAsync(x => x.Id == userId);
             if (user != null)
             {
-                var projectIds = _projectUserRepository.Fetch(x => x.UserId == user.Id).Select(x => x.ProjectId).ToList();
+                var projects = await _projectUserRepository.FetchAsync(x => x.UserId == user.Id);
+                var projectIds = projects.Select(x => x.ProjectId).ToList();
                 List<UserAc> teamLeaders = new List<UserAc>();
                 foreach (var projectId in projectIds)
                 {


### PR DESCRIPTION
Fixes - Issue of ExecuteDbDataReaderAsync occured by ListOfTeamLeaderByUserIdAsync

**1. UserRepository.cs** - used fetchasync instead of fetch in ListOfTeamLeaderByUserIdAsync method