### PR TITLE
Middleware added to intercept request and log request headers

### DIFF
--- a/Promact.Oauth.Server/src/Promact.Oauth.Server/Middleware/OAuthMiddleware.cs
+++ b/Promact.Oauth.Server/src/Promact.Oauth.Server/Middleware/OAuthMiddleware.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Promact.Oauth.Server.Middleware
+{
+    public class OAuthMiddleware
+    {
+        readonly RequestDelegate next;
+        readonly ILogger _logger;
+
+        public OAuthMiddleware(RequestDelegate next, ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger<OAuthMiddleware>();
+            this.next = next;
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            _logger.LogInformation($"Request Headers starts for { context.Request.Path}");
+            context.Request.Headers.Keys.ToList().ForEach(key => _logger.LogInformation($"{ key } - {context.Request.Headers[key]}"));
+            _logger.LogInformation("Request Headers ends");
+            await next.Invoke(context);
+        }
+    }
+}

--- a/Promact.Oauth.Server/src/Promact.Oauth.Server/Startup.cs
+++ b/Promact.Oauth.Server/src/Promact.Oauth.Server/Startup.cs
@@ -32,6 +32,7 @@ using Promact.Oauth.Server.Configuration.DefaultIdentityResource;
 using Promact.Oauth.Server.StringLiterals;
 using NLog.LayoutRenderers;
 using Microsoft.AspNetCore.HttpOverrides;
+using Promact.Oauth.Server.Middleware;
 
 namespace Promact.Oauth.Server
 {
@@ -188,6 +189,8 @@ namespace Promact.Oauth.Server
             }
 
             app.UseStaticFiles();
+
+            app.UseMiddleware<OAuthMiddleware>();
 
             app.UseForwardedHeaders(new ForwardedHeadersOptions
             {


### PR DESCRIPTION
Middleware added to check that X-Forwarded request header gets passed to server or not. 